### PR TITLE
Fix deadlock when the device doesn't respond right away

### DIFF
--- a/examples/XGZP6897D_demo/XGZP6897D_demo.ino
+++ b/examples/XGZP6897D_demo/XGZP6897D_demo.ino
@@ -28,10 +28,10 @@ XGZP6897D mysensor(K);
 float pressure, temperature;
 void setup() {
   Serial.begin(9600);
-  if (!mysensor.begin())  // initialize and check the device
+  while (!mysensor.begin())  // initialize and check the device
   {
     Serial.println("Device not responding.");
-    while (true) delay(10);
+    delay(10);
   }
 }
 

--- a/examples/XGZP6897D_demo/XGZP6897D_demo.ino
+++ b/examples/XGZP6897D_demo/XGZP6897D_demo.ino
@@ -28,10 +28,11 @@ XGZP6897D mysensor(K);
 float pressure, temperature;
 void setup() {
   Serial.begin(9600);
+  delay(100);
   while (!mysensor.begin())  // initialize and check the device
   {
     Serial.println("Device not responding.");
-    delay(10);
+    delay(500);
   }
 }
 

--- a/examples/XGZP6897D_demo_raw/XGZP6897D_demo_raw.ino
+++ b/examples/XGZP6897D_demo_raw/XGZP6897D_demo_raw.ino
@@ -32,10 +32,11 @@ int32_t pressure;
 
 void setup() {
   Serial.begin(9600);
+  delay(100);
   while (!mysensor.begin())  // initialize and check the device
   {
     Serial.println("Device not responding.");
-    delay(10);
+    delay(500);
   }
 }
 

--- a/examples/XGZP6897D_demo_raw/XGZP6897D_demo_raw.ino
+++ b/examples/XGZP6897D_demo_raw/XGZP6897D_demo_raw.ino
@@ -32,10 +32,10 @@ int32_t pressure;
 
 void setup() {
   Serial.begin(9600);
-  if (!mysensor.begin())  // initialize and check the device
+  while (!mysensor.begin())  // initialize and check the device
   {
     Serial.println("Device not responding.");
-    while (true) delay(10);
+    delay(10);
   }
 }
 


### PR DESCRIPTION
Previously, when if the sensor didn't respond right away, the program would get stuck in the while(true) loop