### PR TITLE
Arduino ide can't compile due to unused variable.

### DIFF
--- a/src/XGZP6897D.cpp
+++ b/src/XGZP6897D.cpp
@@ -39,7 +39,7 @@ bool XGZP6897D::readRawSensor(int16_t &rawTemperature, int32_t &rawPressure)
   int16_t  temperature_adc ;
   uint8_t pressure_H, pressure_M, pressure_L, temperature_H, temperature_L;
   uint8_t CMD_reg;
-  unsigned long endConversion, deb;
+  unsigned long endConversion;
   // start conversion
   _Wire->beginTransmission(_I2C_address);
   _Wire->write(0x30);


### PR DESCRIPTION
Hello, thanks for making this library.

I noticed Arduino IDE's compiler flags seem to be set to error on unused variables and understandably refuse to compile. 
Would you consider accepting this PR to make it easier for the next one to find these sensors and this library?
Thank you,
Rob